### PR TITLE
feat: add reset progress button

### DIFF
--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -146,6 +146,21 @@ export default function Layout() {
   const toggleTheme = () => {
     setTheme(prev => (prev === "dark" ? "light" : "dark"));
   };
+  const handleResetProgress = () => {
+    const confirmed = window.confirm(
+      "Are you sure you want to reset all challenge progress?"
+    );
+
+    if (!confirmed) return;
+
+    Object.keys(localStorage).forEach((key) => {
+      if (key.startsWith("completed_")) {
+        localStorage.removeItem(key);
+      }
+    });
+
+    window.dispatchEvent(new Event("completion-change"));
+  };
 
   return (
     <div className="flex h-screen w-full bg-background text-foreground overflow-hidden font-sans selection:bg-accent/30 selection:text-white">
@@ -193,6 +208,12 @@ export default function Layout() {
                 className="h-7 w-48 md:w-64 bg-muted/50 border border-border rounded-md pl-8 pr-3 text-[13px] text-foreground focus:outline-none focus:border-border focus:bg-muted transition-all placeholder:text-muted-foreground/60 shadow-inner"
               />
             </div>
+            <button
+              onClick={handleResetProgress}
+              className="h-7 px-3 rounded-md border border-border bg-muted/50 hover:bg-muted text-[12px] font-medium transition-all"
+            >
+              Reset Progress
+            </button>
             <button
               onClick={toggleTheme}
               className="h-7 w-7 rounded-md border border-border bg-muted/50 hover:bg-muted flex items-center justify-center text-muted-foreground hover:text-foreground transition-all cursor-pointer"


### PR DESCRIPTION
## Summary

This PR adds a **Reset Progress** button to the application.
<img width="1827" height="610" alt="Screenshot 2026-07-21 224054" src="https://github.com/user-attachments/assets/406e393f-7248-4dd5-b6fe-c6ec53edc680" />
<img width="1827" height="610" alt="Screenshot 2026-07-21 224054" src="https://github.com/user-attachments/assets/bff793a3-9c6f-4b98-934f-c0c86798013c" />

**### Changes**
- Added a Reset Progress button to the header.
- Added a confirmation dialog before resetting progress.
- Cleared all saved challenge progress from localStorage.
- Updated the UI immediately after resetting progress.

### Testing
- Verified the Reset Progress button is visible.
- Confirmed the confirmation dialog appears.
- Verified all challenge progress is removed.
- Confirmed progress remains reset after refreshing the page.

Fixes #5

## Screenshots

### Before
<img width="1907" height="537" alt="before 2026-07-21 223914" src="https://github.com/user-attachments/assets/99fd9abf-24ad-45a3-8bac-d53be0c068d3" />
### After
<img width="1827" height="610" alt="after 2026-07-21 224054" src="https://github.com/user-attachments/assets/e72e4086-b96b-4d87-a6f2-cf1aed0da55a" />


