### PR TITLE
Add reset progress feature and improve text selection visibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,27 +29,6 @@
         "vite": "^8.1.1"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -665,6 +644,27 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
@@ -982,6 +982,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1528,6 +1529,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1577,6 +1579,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1586,6 +1589,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -1751,6 +1755,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,6 +1,6 @@
 import { NavLink, Outlet, useLocation } from "react-router-dom";
 import { useState, useEffect } from "react";
-import { Database, Home, MousePointerClick, Filter, ArrowDownAZ, Search, Settings, TerminalSquare, Scissors, FolderTree, Combine, Menu, X, ChevronRight, Check, Layers, Tag, Sun, Moon } from "lucide-react";
+import { Database, Home, MousePointerClick, Filter, ArrowDownAZ, Search, Settings, TerminalSquare, Scissors, FolderTree, Combine, Menu, X, ChevronRight, Check, Layers, Tag, Sun, Moon, RefreshCw } from "lucide-react";
 import { cn } from "../utils/cn";
 
 const links = [
@@ -39,7 +39,7 @@ function SidebarContent({ onClose }) {
 
   return (
     <>
-      <div className="h-12 px-4 border-b border-border flex items-center gap-2 flex-shrink-0">
+      <div className="h-12 px-4 border-b border-border flex items-center gap-2 shrink-0">
         <div className="w-5 h-5 rounded flex items-center justify-center bg-foreground text-background shadow-sm">
           <Database size={12} strokeWidth={2.5} />
         </div>
@@ -51,7 +51,7 @@ function SidebarContent({ onClose }) {
         )}
       </div>
 
-      <nav className="flex-1 py-4 px-2 space-y-[2px] overflow-y-auto">
+      <nav className="flex-1 py-4 px-2 space-y-0.5 overflow-y-auto">
         <div className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest mb-1 px-3">Start Here</div>
 
         {/* Overview link */}
@@ -90,14 +90,14 @@ function SidebarContent({ onClose }) {
             }
           >
             <div className={cn(
-              "w-5 h-5 rounded flex items-center justify-center text-[10px] font-bold flex-shrink-0 transition-all duration-200",
+              "w-5 h-5 rounded flex items-center justify-center text-[10px] font-bold shrink-0 transition-all duration-200",
               completedPaths[link.to]
                 ? "bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 shadow-[0_0_8px_rgba(16,185,129,0.15)]"
                 : "bg-muted text-muted-foreground group-hover:text-foreground border border-border/40"
             )}>
               {completedPaths[link.to] ? <Check size={10} strokeWidth={3} /> : link.step}
             </div>
-            <link.icon size={13} strokeWidth={2.5} className="flex-shrink-0" />
+            <link.icon size={13} strokeWidth={2.5} className="shrink-0" />
             <span className="flex-1">{link.label}</span>
             <span className={cn("text-[9px] font-bold px-1.5 py-0.5 rounded-full hidden lg:block", link.diffColor)}>
               {link.difficulty === "Beginner" ? "BGN" : link.difficulty === "Intermediate" ? "INT" : "ADV"}
@@ -147,11 +147,27 @@ export default function Layout() {
     setTheme(prev => (prev === "dark" ? "light" : "dark"));
   };
 
+  const handleResetProgress = () => {
+  const confirmed = window.confirm(
+    "Are you sure you want to reset all challenge progress?"
+  );
+
+  if (!confirmed) return;
+
+  Object.keys(localStorage).forEach((key) => {
+    if (key.startsWith("completed_")) {
+      localStorage.removeItem(key);
+    }
+  });
+
+  window.dispatchEvent(new Event("completion-change"));
+};
+
   return (
-    <div className="flex h-screen w-full bg-background text-foreground overflow-hidden font-sans selection:bg-accent/30 selection:text-white">
+    <div className="flex h-screen w-full bg-background text-foreground overflow-hidden font-sans">
 
       {/* Desktop Sidebar */}
-      <aside className="hidden md:flex w-[220px] border-r border-border bg-card flex-col flex-shrink-0">
+      <aside className="hidden md:flex w-55 border-r border-border bg-card flex-col shrink-0">
         <SidebarContent />
       </aside>
 
@@ -159,7 +175,7 @@ export default function Layout() {
       {mobileOpen && (
         <div className="fixed inset-0 z-50 md:hidden">
           <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setMobileOpen(false)} />
-          <aside className="absolute left-0 top-0 h-full w-[260px] bg-card border-r border-border flex flex-col z-10 shadow-2xl">
+          <aside className="absolute left-0 top-0 h-full w-65 bg-card border-r border-border flex flex-col z-10 shadow-2xl">
             <SidebarContent onClose={() => setMobileOpen(false)} />
           </aside>
         </div>
@@ -193,15 +209,28 @@ export default function Layout() {
                 className="h-7 w-48 md:w-64 bg-muted/50 border border-border rounded-md pl-8 pr-3 text-[13px] text-foreground focus:outline-none focus:border-border focus:bg-muted transition-all placeholder:text-muted-foreground/60 shadow-inner"
               />
             </div>
+
+            <button
+              onClick={handleResetProgress}
+              className="h-7 w-7 rounded-md border border-border bg-muted/50 hover:bg-muted flex items-center justify-center text-muted-foreground hover:text-foreground transition-all cursor-pointer"
+              aria-label="Reset progress"
+              title="Reset progress"
+            >
+              <RefreshCw size={14} />
+            </button>
+
             <button
               onClick={toggleTheme}
               className="h-7 w-7 rounded-md border border-border bg-muted/50 hover:bg-muted flex items-center justify-center text-muted-foreground hover:text-foreground transition-all cursor-pointer"
               aria-label="Toggle theme"
+              title="Toggle theme"
             >
               {theme === "dark" ? <Sun size={14} /> : <Moon size={14} />}
             </button>
           </div>
         </header>
+
+        
 
         {/* Page Content */}
         <div className="flex-1 overflow-y-auto">

--- a/src/hooks/useChallenges.js
+++ b/src/hooks/useChallenges.js
@@ -17,6 +17,19 @@ export function useChallenges(challenges) {
   const currentStatus = statuses[currentIdx];
   const allPassed = statuses.every((s) => s === "pass");
 
+  useEffect(() => {
+    const handleCompletionChange = () => {
+      const path = window.location.pathname;
+      if (localStorage.getItem("completed_" + path) !== "true") {
+        setStatuses(challenges.map(() => "idle"));
+        setCurrentIdx(0);
+      }
+    };
+
+    window.addEventListener("completion-change", handleCompletionChange);
+    return () => window.removeEventListener("completion-change", handleCompletionChange);
+  }, [challenges]);
+
   const checkAnswer = (resultSetData, parsedAST) => {
     const passed = current.validate(resultSetData, parsedAST);
     setStatuses((prev) => {

--- a/src/hooks/useExecutionEngine.js
+++ b/src/hooks/useExecutionEngine.js
@@ -405,6 +405,26 @@ export function useExecutionEngine(initialQuery = "") {
     }
   }, [isFinished]);
 
+  useEffect(() => {
+    const handleCompletionChange = () => {
+      const path = window.location.pathname;
+      if (localStorage.getItem("completed_" + path) !== "true") {
+        setIsFinished(false);
+        setIsPlaying(false);
+        setIsPaused(false);
+        setStep(-1);
+        setCurrentRowIdx(-1);
+        setHighlightedRows([]);
+        setCheckingCondition(false);
+        setResultSetData([]);
+        setCurrentRightRowIdx(-1);
+      }
+    };
+
+    window.addEventListener("completion-change", handleCompletionChange);
+    return () => window.removeEventListener("completion-change", handleCompletionChange);
+  }, []);
+
   return {
     queryInput,
     setQueryInput,

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,8 @@
     --accent: #6366f1;
     --danger: #ef4444;
     --success: #10b981;
+    --selection-bg: #6366f1;
+    --selection-fg: #ffffff;
   }
 
   .dark {
@@ -45,10 +47,44 @@
     --accent: #6366f1;
     --danger: #ef4444;
     --success: #10b981;
+    --selection-bg: #6366f1;
+    --selection-fg: #ffffff;
   }
 
   * {
     border-color: var(--border);
+  }
+
+  /* Global text selection — high contrast indigo highlight across light and dark themes */
+  ::selection {
+    background-color: var(--selection-bg);
+    color: var(--selection-fg);
+  }
+
+  ::-moz-selection {
+    background-color: var(--selection-bg);
+    color: var(--selection-fg);
+  }
+
+  /* Code editors and text inputs explicit selection rule */
+  textarea::selection,
+  input::selection,
+  pre::selection,
+  code::selection,
+  .query-textarea::selection,
+  .npm__react-simple-code-editor__textarea::selection {
+    background-color: var(--selection-bg);
+    color: var(--selection-fg);
+  }
+
+  textarea::-moz-selection,
+  input::-moz-selection,
+  pre::-moz-selection,
+  code::-moz-selection,
+  .query-textarea::-moz-selection,
+  .npm__react-simple-code-editor__textarea::-moz-selection {
+    background-color: var(--selection-bg);
+    color: var(--selection-fg);
   }
 
   body {
@@ -78,11 +114,16 @@
 
 @layer utilities {
   .panel {
-    @apply bg-[var(--card)] border border-[var(--border)] rounded-lg shadow-sm;
+    background-color: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   }
   
   .dark .panel {
-    @apply bg-[var(--card)] border border-[var(--border)] shadow-none;
+    background-color: var(--card);
+    border: 1px solid var(--border);
+    box-shadow: none;
   }
   
   /* SaaS glowing grid background */
@@ -97,15 +138,5 @@
   .dark .bg-grid-pattern {
     background-image: linear-gradient(to right, rgba(255, 255, 255, 0.05) 1px, transparent 1px),
                       linear-gradient(to bottom, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
-  }
-
-  /* Query editor text selection — clearly visible indigo highlight */
-  .query-textarea::selection {
-    background-color: rgba(99, 102, 241, 0.35);
-    color: #fff;
-  }
-  .query-textarea::-moz-selection {
-    background-color: rgba(99, 102, 241, 0.35);
-    color: #fff;
   }
 }


### PR DESCRIPTION
## Summary

### Added
- Added a Reset Progress button with a confirmation dialog.
- Clears only challenge progress (`completed_*`) while preserving the theme preference.
- Updates the sidebar after reset.

### Improved
- Improved text selection visibility in both Light and Dark themes.

## Testing
- Verified challenge completion persists after solving (intended behavior).
- Verified Reset Progress clears saved progress.
- Verified theme preference remains unchanged.
- Verified text selection is clearly visible in both themes.
