### PR TITLE
feat: add Ctrl+Enter keyboard shortcut to run queries

### DIFF
--- a/src/components/Query.jsx
+++ b/src/components/Query.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { cn } from "../utils/cn";
 import { Play, RotateCcw, Terminal, PencilLine, Lock, Pause, SkipForward, Gauge, Trash2, Copy, Check } from "lucide-react";
 
@@ -26,6 +26,19 @@ export default function Query({
 }) {
   const isEditable = !isPlaying && !isFinished;
   const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    const handler = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        if (isEditable && !isFinished) {
+          onRun?.();
+        }
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [isEditable, isFinished, onRun]);
 
   const handleCopy = async () => {
     try {
@@ -143,7 +156,7 @@ export default function Query({
           </div>
         ) : (
           <div className="text-[10px] text-zinc-600 font-mono hidden sm:block">
-            {isEditable ? "Edit the query above, then press Run" : ""}
+            {isEditable ? "Edit the query above, then press Run or Ctrl / Cmd + Enter" : ""}
           </div>
         )}
 
@@ -186,6 +199,7 @@ export default function Query({
               onClick={onRun}
               disabled={isFinished}
               className="flex items-center gap-1.5 px-4 py-1.5 rounded bg-accent text-white text-xs font-medium transition-all hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm active:scale-95"
+              title="Run query (Ctrl / Cmd + Enter)"
             >
               <Play size={13} fill="currentColor" />
               Run Query


### PR DESCRIPTION
## Description

Adds Ctrl+Enter (Windows) / Cmd+Enter (Mac) keyboard shortcut to execute queries directly from the editor, so users don't need to click the Run button.

Closes #15

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Code refactor or performance improvement

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have verified the app runs without crashing locally (`npm run dev`)
- [x] My changes generate no new warnings in the console
- [x] I have tested this change against multiple modules/queries if applicable